### PR TITLE
Downgrade libxml2

### DIFF
--- a/7.0/scripts/install.sh
+++ b/7.0/scripts/install.sh
@@ -20,5 +20,8 @@ sed -e 's/\(max_nesting_level\).*/\1=1000/' \
 curl -sS -o /usr/local/bin/magerun https://files.magerun.net/n98-magerun2.phar
 chmod +x /usr/local/bin/magerun
 
+# downgrade libxml2, magento unit tests fail on libxml2 2.9.12
+apt-get install libxml2=2.9.4+dfsg1-7+deb10u2 -y --allow-downgrades
+
 # update permissions to allow rootless operation
 /usr/local/bin/permissions

--- a/7.1/scripts/install.sh
+++ b/7.1/scripts/install.sh
@@ -20,5 +20,8 @@ sed -e 's/\(max_nesting_level\).*/\1=1000/' \
 curl -sS -o /usr/local/bin/magerun https://files.magerun.net/n98-magerun2.phar
 chmod +x /usr/local/bin/magerun
 
+# downgrade libxml2, magento unit tests fail on libxml2 2.9.12
+apt-get install libxml2=2.9.4+dfsg1-7+deb10u2 -y --allow-downgrades
+
 # update permissions to allow rootless operation
 /usr/local/bin/permissions

--- a/7.2/scripts/install.sh
+++ b/7.2/scripts/install.sh
@@ -20,5 +20,8 @@ sed -e 's/\(max_nesting_level\).*/\1=1000/' \
 curl -sS -o /usr/local/bin/magerun https://files.magerun.net/n98-magerun2.phar
 chmod +x /usr/local/bin/magerun
 
+# downgrade libxml2, magento unit tests fail on libxml2 2.9.12
+apt-get install libxml2=2.9.4+dfsg1-7+deb10u2 -y --allow-downgrades
+
 # update permissions to allow rootless operation
 /usr/local/bin/permissions

--- a/7.3/scripts/install.sh
+++ b/7.3/scripts/install.sh
@@ -20,5 +20,8 @@ sed -e 's/\(max_nesting_level\).*/\1=1000/' \
 curl -sS -o /usr/local/bin/magerun https://files.magerun.net/n98-magerun2.phar
 chmod +x /usr/local/bin/magerun
 
+# downgrade libxml2, magento unit tests fail on libxml2 2.9.12
+apt-get install libxml2=2.9.4+dfsg1-7+deb10u2 -y --allow-downgrades
+
 # update permissions to allow rootless operation
 /usr/local/bin/permissions

--- a/7.4/scripts/install.sh
+++ b/7.4/scripts/install.sh
@@ -20,5 +20,8 @@ sed -e 's/\(max_nesting_level\).*/\1=1000/' \
 curl -sS -o /usr/local/bin/magerun https://files.magerun.net/n98-magerun2.phar
 chmod +x /usr/local/bin/magerun
 
+# downgrade libxml2, magento unit tests fail on libxml2 2.9.12
+apt-get install libxml2=2.9.4+dfsg1-7+deb10u2 -y --allow-downgrades
+
 # update permissions to allow rootless operation
 /usr/local/bin/permissions


### PR DESCRIPTION
The libxml2 version 2.9.12 breaks 158 unit tests in Magento.
Downgrading solves this.

Example failures:
```
158) Magento\Framework\ObjectManager\Test\Unit\Config\XsdTest::testSchemaCorrectlyIdentifiesInvalidXml with data set "virtualtype with digits_and_prefix_slash" ('<config xmlns:xsi="http://www...onfig>', array('Element 'virtualType', att
rib...e: 2\n', 'Element 'virtualType', attrib...e: 2\n', 'Element 'virtualType', attrib...e: 2\n'))
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     0 => 'Element 'virtualType', attrib...e: 2\n'
-    1 => 'Element 'virtualType', attribute 'name': '\777Digits\IsNotAllowed' is not a valid value of the atomic type 'phpClassName'.\n
+    1 => 'Element 'virtualType', attribute 'name': Warning: No precomputed value available, the value was either invalid or something strange happened.\n
     Line: 2\n
     '
-    2 => 'Element 'virtualType', attrib...e: 2\n'
 )
```

```
144) Magento\Framework\App\Test\Unit\Config\XsdTest::testSchemaCorrectlyIdentifiesInvalidXml with data set "route_module_name_attribute_value_regexp1" ('<?xml version="1.0"?><config>...onfig>', array('Element 'module', attribute '...e:
1\n', 'Element 'module', attribute '...e: 1\n', 'Element 'module', attribute '...e: 1\n'))
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     0 => 'Element 'module', attribute '...e: 1\n'
-    1 => 'Element 'module', attribute 'name': 'ss' is not a valid value of the atomic type 'moduleNameType'.\n
+    1 => 'Element 'module', attribute 'name': Warning: No precomputed value available, the value was either invalid or something strange happened.\n
     Line: 1\n
     '
-    2 => 'Element 'module', attribute '...e: 1\n'
 )
```

Used 2.9.4 because of:

```
root@acfcaf259056:/phpapp# apt list -a libxml2
Listing... Done
libxml2/buster 2.9.12+dfsg-0+0~20210621.9+debian10~1.gbp43e861 amd64 [upgradable from: 2.9.4+dfsg1-7+deb10u2]
libxml2/stable,now 2.9.4+dfsg1-7+deb10u2 amd64 [installed,upgradable to: 2.9.12+dfsg-0+0~20210621.9+debian10~1.gbp43e861]
```